### PR TITLE
[SCS-526] 16KB 메모리 페이징 대응

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,10 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
+        }
 
         manifestPlaceholders["APP_URL"] = getApiKey("app.url")
         manifestPlaceholders["KAKAO_NATIVE_KEY"] = getApiKey("kakao.key.native")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,20 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keepattributes *Annotation*
+-keepclassmembers class * {
+    @androidx.annotation.Keep *;
+}
+-keep @androidx.annotation.Keep class *
+-keepclassmembers class * {
+    @androidx.annotation.Keep <methods>;
+}
+-keepclassmembers class * {
+    @androidx.annotation.Keep <fields>;
+}
+
+-optimizations !code/simplification/arithmetic,!code/simplification/cast,!field/*,!class/merging/*
+-optimizationpasses 5
+-allowaccessmodification
+-dontpreverify

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@drawable/app_icon"
         android:supportsRtl="true"
         android:theme="@style/Theme.Sachosaeng"
-        tools:targetApi="31">
+        android:largeHeap="true"
+        tools:targetApi="35">
         <activity
             android:name=".main.MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/sachosaeng/App.kt
+++ b/app/src/main/java/com/example/sachosaeng/App.kt
@@ -1,6 +1,7 @@
 package com.sachosaeng.app
 
 import android.app.Application
+import android.os.Build
 import com.google.firebase.FirebaseApp
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
@@ -10,6 +11,11 @@ import dagger.hilt.android.HiltAndroidApp
 class App: Application() {
     override fun onCreate() {
         super.onCreate()
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            System.setProperty("dalvik.vm.dex2oat-flags", "--compiler-filter=speed")
+        }
+        
         FirebaseApp.initializeApp(this)
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_KEY)
     }


### PR DESCRIPTION
- 앱이 더 큰 힙 메모리를 사용할 수 있도록 허용
- Android 15 (API 35)를 타겟으로 한다는 것을 명시
- 네이티브 라이브러리를 특정 아키텍처에만 포함
- 중요한 어노테이션과 @Keep 어노테이션이 붙은 클래스/메서드 보존
- ProGuard 최적화 설정으로 메모리 사용량 최적화
- DEX2OAT 컴파일러 최적화